### PR TITLE
Force build only for jruby and update logstash core api version range

### DIFF
--- a/logstash-integration-zeromq.gemspec
+++ b/logstash-integration-zeromq.gemspec
@@ -17,8 +17,17 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "pack" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
-  s.add_runtime_dependency "ffi-rzmq", "~> 2.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 2.0", "<= 5.99"
+  s.add_runtime_dependency "ffi-rzmq", "~> 2.0.5"
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-codec-json'
+  
+  # Make sure we dont build this gem from a non jruby
+  # environment.
+  if RUBY_PLATFORM == "java"
+    s.platform = "java"
+  else
+    raise "The logstash-integration-zeromq needs to be build on jruby"
+  end
+
 end


### PR DESCRIPTION
I needed this to be able to build and use it in logstash-5.4.1.